### PR TITLE
Disabled QRadar collection version warning

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,10 +1,15 @@
 [defaults]
-stdout_callback = yaml
 forks          = 50
-retry_files_enabled = False
-interpreter_python = auto_silent
+stdout_callback = yaml
+connection = smart
+timeout = 60
+deprecation_warnings = False
+action_warnings = False
 system_warnings = False
 host_key_checking = False
+collections_on_ansible_version_mismatch = ignore
+retry_files_enabled = False
+interpreter_python = auto_silent
 
 [persistent_connection]
 connect_timeout = 60


### PR DESCRIPTION
Updated ansible.cfg to mute IBM QRadar collection version warnings using AAP 2.0 (Ansible-core 2.11.2)