### PR TITLE
Qradar idps fqdn

### DIFF
--- a/qradar_snort_log.yml
+++ b/qradar_snort_log.yml
@@ -11,4 +11,4 @@
         type_name: "Snort Open Source IDS"
         state: present
         description: "Snort rsyslog source"
-        identifier: "{{ hostvars['snort']['private_ip']|regex_replace('\\.','-')|regex_replace('^(.*)$', 'ip-\\1') }}"
+        identifier: "{{ hostvars['snort']['ansible_fqdn'] }}" 


### PR DESCRIPTION
#### Summary

- Current QRadar Snort log identifier `"{{ hostvars['snort']['private_ip']|regex_replace('\\.','-')|regex_replace('^(.*)$', 'ip-\\1') }}"` 
  - This shows unknown source in QRadar log events
- Updated to use `"{{ hostvars['snort']['ansible_fqdn'] }}"`